### PR TITLE
fix formating in _pub_1999_01_y2k.md

### DIFF
--- a/content/legacy/_pub_1999_01_y2k.md
+++ b/content/legacy/_pub_1999_01_y2k.md
@@ -49,7 +49,7 @@ The second lie is that this phenomenon is somehow brand new, that in the year 20
 
 The third, and by far the gravest lie about Y2K matters, is that your company can, through the acquisition of affidavits of compliance, protect itself against harm, whether real or litigated. It can't. This faith in legal documents is hollow and in fact dangerous. The wisest course of action is for you to immediately disabuse yourself of this deceit.
 
-The insidious, underlying root cause of this entire problem is neither the hardware nor the software. No, that would be too easy; that we know how to fix. Just apply a few hundred billion dollars, and voil�, it's all taken care of.
+The insidious, underlying root cause of this entire problem is neither the hardware nor the software. No, that would be too easy; that we know how to fix. Just apply a few hundred billion dollars, and voilà, it's all taken care of.
 
 Unfortunately, that's not it. The real problem is the wetware. That's right: the defect lies not in our computers, nor in their programming, but rather in ourselves.
 
@@ -83,7 +83,7 @@ To seek legally binding statements that a particular program cannot be intention
 ### Perl
 
 Now, what about Perl? Is Perl \`\`Year 2000 Compliant''? The answer is that Perl is every bit as Y2K compliant as is your pencil; no more, and no less. Does that comfort you? It shouldn't. Just as you can commit Y2K transgressions with your pencil, so too you can do so with Perl -- or with any other tool, for that matter. You don't really even have to go very far out of your way to do so; witness the demonstration of the perfectly compliant *cal* program provided above.
-The date and time functions supplied with Perl are the `gmtime()` and `localtime() functions, which are derived from their namesakes from the C programming language.  These supply adequate information to determine the year well beyond 2000.  2038 is when trouble strikes, but only for those of us still stuck on 32-bit machines, a somewhat unlikely albeit admittedly not entirely unthinkable situation.   `
+The date and time functions supplied with Perl are the `gmtime()` and `localtime()` functions, which are derived from their namesakes from the C programming language.  These supply adequate information to determine the year well beyond 2000.  2038 is when trouble strikes, but only for those of us still stuck on 32-bit machines, a somewhat unlikely albeit admittedly not entirely unthinkable situation.
 
 The year returned by these functions (when used in list context) is, contrary to popular misconception, *not* by definition a two-digit year. Rather, it merely happens to be such right now. What it actually is, is the current year minus one thousand nine hundred. For years between 1900 and 1999 this happens to be a 2-digit decimal number, but that's not going to last long. To avoid the year 2000 problem, simply do not treat the year as a 2-digit number. Easy to say, and easy to break. Imagine that you want find out what the year appears to be in five years, so you write code like this.
 


### PR DESCRIPTION
(Hopefully) fixed the encoding problem in "voilà".
And restricted the monowidth region to the function name in the paragraph
about the time functions, the first paragraph in Perl section.