### PR TITLE
Correcting 2 minor mistakes

### DIFF
--- a/content/legacy/_pub_2008_04_23_a-beginners-introduction-to-perl-510.md
+++ b/content/legacy/_pub_2008_04_23_a-beginners-introduction-to-perl-510.md
@@ -231,7 +231,7 @@ A handy shortcut for defining loop values is the *range* operator `..`, which sp
 
 Of course, again you could write `say @one_to_ten, 15, 20 .. $top_limit;`
 
-The items in your loop list don't have to be numbers; you can use strings just as easily. If the hash `%month`\_has contains names of months and the number of days in each month, you can use the `keys` function to step through them.
+The items in your loop list don't have to be numbers; you can use strings just as easily. If the hash `%month_has` contains names of months and the number of days in each month, you can use the `keys` function to step through them.
 
     use feature ':5.10';
 

--- a/static/media/_pub_2008_04_23_a-beginners-introduction-to-perl-510/compound_interest.pl
+++ b/static/media/_pub_2008_04_23_a-beginners-introduction-to-perl-510/compound_interest.pl
@@ -25,7 +25,7 @@ for my $i ( 1 .. $duration )
     print $nest_egg, "\t";
 
     # Try using this instead to see why this line looks so complex:
-    # my $interest = ($apr / 100) * $nest_egg
+    # my $interest = ($apr / 100) * $nest_egg;
     my $interest = int( ( $apr / 100 ) * $nest_egg * 100 ) / 100;
     print $interest, "\t";
 


### PR DESCRIPTION
Correcting a variable that had an erroneous space and a missing semi-colon from a commented example script.