### PR TITLE
Convert a few search.cpan links to metacpan

### DIFF
--- a/content/legacy/_pub_2004_09_12_embedded.md
+++ b/content/legacy/_pub_2004_09_12_embedded.md
@@ -61,7 +61,7 @@ Here then is a code snippet that demonstrates the use of `Tie::File` to our stri
 
       # do something smart...
     }
-         
+
 
 There is no question that this program requires heavy disk access, and if we had additional information about the data in question, we should try hard to use it and avoid the brute force approach of comparing "everything to everything". However, if we have no choice, then `Tie::File` makes code like the above as efficient as can be: It does not attempt to load the entire file into memory, so that arbitrarily large files can be processed. The first time we iterate over the file, `Tie::File` builds up an index containing the offset of each record from the beginning of the file, so that subsequent accesses can go directly to the proper position in the file using `seek()`. Finally, accessed records are cached in memory and the cache size can be adjusted passing the `memory` option to the `tie` command.
 
@@ -92,7 +92,7 @@ The following code opens a Berkeley DB (creating a new file, if necessary) and w
     print "$login:\t$uid|$gid $name \t$home\t$shell\n";
 
     $db->db_close();
-          
+
 
 The code above uses the Perl interface to the Berkeley DB modelled after its C API. The `BerkeleyDB` module also supports a `tie` interface, tying the database file to a Perl hash, making code like the following possible: `$hash{ $login } = join( ':', @info );`. The API-style interface, on the other hand, follows the native interface of the Berkeley DB quite closely, which means that most of the (quite extensive) original C API documentation also applies when programming Perl - which is good, since the perldoc for `BerkeleyDB` is a bit sketchy in places. Try `man db_intro` to get started on the native Berkeley DB interface, or visit the Berkeley DB's homepage.
 
@@ -141,7 +141,7 @@ We begin by `connecting` to the SQLite database contained in the file "`data.dbl
     }
 
     $dbh->disconnect;
-          
+
 
 The `books` table references the `authors` table via a foreign key. This is a one-to-many relationship: each book has only a single author, but an author can have written multiple books. What would we have done if books could have been co-authored by multiple writers? We would have used a cross-reference table to represent the resulting many-to-many relationship. Try *that* with Berkeley DBs!
 
@@ -158,6 +158,5 @@ In this paper, we considered three ways to add database capabilities to a Perl p
 -   [`Tie::File` Home Page](http://perl.plover.com/TieFile)
 -   [Berkeley DB Home Page](http://www.sleepycat.com/)
 -   [SQLite Home Page](http://www.sqlite.org/)
--   [Perl DBI Driver for SQLite on CPAN](http://search.cpan.org/~msergeant/DBD-SQLite-0.31/lib/DBD/SQLite.pm)
+-   [Perl DBI Driver for SQLite on CPAN](https://metacpan.org/pod/DBD::SQLite)
 -   [Practical Database Design](http://www-106.ibm.com/developerworks/web/library/wa-dbdsgn2.html) A brief introduction to the representation of relationships in relational DBs and to DB Normalization.
-

--- a/content/legacy/_pub_2005_12_08_test_files.md
+++ b/content/legacy/_pub_2005_12_08_test_files.md
@@ -26,11 +26,11 @@ For the last several years, there has been more and more emphasis on automated t
 
 ### Introduction
 
-My boss put me to work writing a moderately large suite in Perl. Among many other things, it needed to perform check out and commit operations on CVS repositories. In a quest to build quality tests for that module, I wrote [`Test::Files`](http://search.cpan.org/perldoc/Test::Files), which is now on CPAN. This article explains how to use that module and, perhaps more importantly, how it tests itself.
+My boss put me to work writing a moderately large suite in Perl. Among many other things, it needed to perform check out and commit operations on CVS repositories. In a quest to build quality tests for that module, I wrote [`Test::Files`](https://metacpan.org/pod/Test::Files), which is now on CPAN. This article explains how to use that module and, perhaps more importantly, how it tests itself.
 
 ### Using `Test::Files`
 
-To use `Test::Files`, first use [`Test::More`](http://search.cpan.org/perldoc/Test::More) and tell it how many tests you want to run.
+To use `Test::Files`, first use [`Test::More`](https://metacpan.org/pod/Test::More) and tell it how many tests you want to run.
 
     use strict;
     use warnings;
@@ -85,7 +85,7 @@ If knowing that certain file names are present is not enough, use the `compare_d
 
 This will generate a separate diagnostic `diff` output for each pair of files that differs, in addition to listing files that are missing from either distribution. (If you need to know which files are missing from the built directory, either reverse the order of the directories or use `dir_only_contains_ok` in addition to `compare_dirs_ok`. This is a bug and might eventually be fixed.) Even though this could yield many diagnostic reports, all of those separate failures only count as one failed test.
 
-There are many times when testing *all* files in the directories is just wrong. In these cases, it is best to use [`File::Find`](http://search.cpan.org/perldoc/File::Find) or an equivalent, putting an exclusion criterion at the top of your wanted function and a call to `compare_ok` at the bottom. This probably requires you to use `no_plan` with `Test::More`:
+There are many times when testing *all* files in the directories is just wrong. In these cases, it is best to use [`File::Find`](https://metacpan.org/pod/File::Find) or an equivalent, putting an exclusion criterion at the top of your wanted function and a call to `compare_ok` at the bottom. This probably requires you to use `no_plan` with `Test::More`:
 
     use Test::More qw(no_plan);
 
@@ -126,7 +126,7 @@ In addition to `compare_dirs_filter_ok` for whole directory structures, there is
 
 ### Testing a Test Module
 
-The most interesting part of writing `Test::Files` was learning how to test it. Thanks to Schwern, I learned about [`Test::Builder::Tester`](http://search.cpan.org/perldoc/Test::Builder::Tester), which eases the problems inherent in testing a Perl test module.
+The most interesting part of writing `Test::Files` was learning how to test it. Thanks to Schwern, I learned about [`Test::Builder::Tester`](https://metacpan.org/pod/Test::Builder::Tester), which eases the problems inherent in testing a Perl test module.
 
 The difficulty with testing Perl tests has to do with how they normally run. The venerable test harness scheme expects test scripts to produce pass and fail data on standard out and diagnostic help on standard error. This is a great design. The simplicity is exactly what you would expect from a Unix-inspired tool. Yet, it poses a problem for testing test modules.
 

--- a/content/legacy/_pub_2010_03_idioms-or-how-to-write-perlish-perl.md
+++ b/content/legacy/_pub_2010_03_idioms-or-how-to-write-perlish-perl.md
@@ -30,13 +30,13 @@ As you learn Perl 5 in more detail, you will begin to see and understand common 
 
 [Perl 5's object system](http://learnperl.scratchcomputing.com/tutorials/objects/) treats the invocant of a method as a mundane parameter. The invocant of a class method (a string containing the name of the class) is that method's first parameter. The invocant of an object or instance method, the object itself, is that method's first parameter. You are free to use or ignore it as you see fit.
 
-Idiomatic Perl 5 uses `$class` as the name of the class method and `$self` for the name of the object invocant. This is a convention not enforced by the language itself, but it is a convention strong enough that useful extensions such as [MooseX::Method::Signatures](http://search.cpan.org/perldoc?MooseX::Method::Signatures) assume you will use `$self` as the name of the invocant by default.
+Idiomatic Perl 5 uses `$class` as the name of the class method and `$self` for the name of the object invocant. This is a convention not enforced by the language itself, but it is a convention strong enough that useful extensions such as [MooseX::Method::Signatures](https://metacpan.org/pod/MooseX::Method::Signatures) assume you will use `$self` as the name of the invocant by default.
 
 This is true even if you use [Moose](http://moose.perl.org/).
 
 #### **Named Parameters**
 
-Without a module such as [signatures](http://search.cpan.org/perldoc?signatures) or [MooseX::Multimethods](http://search.cpan.org/perldoc?MooseX::Multimethods), Perl 5's argument passing mechanism is simple: all arguments flatten into a single list accessible through `@_` (function\_parameters). While this simplicity is occasionally too simple—named parameters can be very useful at times—it does not preclude the use of idioms to provide named parameters.
+Without a module such as [signatures](https://metacpan.org/pod/signatures) or [MooseX::Multimethods](https://metacpan.org/pod/MooseX::MultiMethods), Perl 5's argument passing mechanism is simple: all arguments flatten into a single list accessible through `@_` (function\_parameters). While this simplicity is occasionally too simple—named parameters can be very useful at times—it does not preclude the use of idioms to provide named parameters.
 
 The list context evaluation and assignment of `@_` allows you to unpack named parameters pairwise. Even though this function call is equivalent to passing a comma-separated or `qw//`-created list, arranging the arguments as if they were true pairs of keys and values makes the caller-side look like the function supports named parameters:
 


### PR DESCRIPTION
Note that the first two items on the [conversion list](https://github.com/dnmfarrell/perldotcom/issues/77#issuecomment-389902737) have already updated:

    perldotcom/content/legacy/_pub_2011_02_perl-qa-hackathon-2011-call-to-attention.md
    perldotcom/content/legacy/_pub_2012_06_perlunicook-case--and-accent-insensitive-comparison.md